### PR TITLE
Fixed requirements.txt to make it work with non-Mac systems

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-pyobjc-core==4.0
-pyobjc==4.0
+pyobjc-core==4.0; sys_platform == 'darwin'
+pyobjc==4.0; sys_platform == 'darwin'
+python-xlib==0.20
 PyAutoGUI==0.9.36
 numpy==1.11.1rc1


### PR DESCRIPTION
By adding Environment Markers pip will now ignore the first two lines on non-mac systems. As PyObjC isn't available on Linux.

Also added a requirement for python-xlib as PyAutoGUI was failing to install in a virtualenv without it.

Cannot test that it still works on Mac as i don't have access to one to try it.